### PR TITLE
Element matrices

### DIFF
--- a/docs/modules.rst
+++ b/docs/modules.rst
@@ -35,6 +35,8 @@ Finite Element Modules
    pymoto.AssembleGeneral
    pymoto.AssembleStiffness
    pymoto.AssembleMass
+   pymoto.AssembleScalarMass
+   pymoto.AssembleScalarField
 
 Filter Modules
 --------------

--- a/pymoto/__init__.py
+++ b/pymoto/__init__.py
@@ -13,7 +13,7 @@ from .common.solvers_sparse import SolverSparsePardiso, SolverSparseLU, SolverSp
 from .core_objects import Signal, Module, Network, make_signals
 
 # Import modules
-from .modules.assembly import AssembleGeneral, AssembleStiffness, AssembleMass
+from .modules.assembly import AssembleGeneral, AssembleStiffness, AssembleMass, AssembleScalarMass, AssembleScalarField
 from .modules.autodiff import AutoMod
 from .modules.complex import MakeComplex, RealPart, ImagPart, ComplexNorm
 from .modules.filter import FilterConv, Filter, DensityFilter, OverhangFilter
@@ -39,7 +39,7 @@ __all__ = [
     # Modules
     "MathGeneral", "EinSum", "ConcatSignal",
     "Inverse", "LinSolve", "EigenSolve", "SystemOfEquations", "StaticCondensation",
-    "AssembleGeneral", "AssembleStiffness", "AssembleMass",
+    "AssembleGeneral", "AssembleStiffness", "AssembleMass", "AssembleScalarMass", "AssembleScalarField",
     "FilterConv", "Filter", "DensityFilter", "OverhangFilter",
     "PlotDomain", "PlotGraph", "PlotIter", "WriteToVTI",
     "MakeComplex", "RealPart", "ImagPart", "ComplexNorm",

--- a/pymoto/modules/assembly.py
+++ b/pymoto/modules/assembly.py
@@ -281,8 +281,8 @@ class AssembleMass(AssembleGeneral):
 
     def _prepare(self, domain: DomainDefinition, *args, rho: float = 1.0, bcdiagval=0.0, **kwargs):
         # Element mass matrix
-        ME = ConsistentMassEq(domain, ndof=domain.dim, MP=rho)
-        super()._prepare(domain, ME, *args, bcdiagval=bcdiagval, **kwargs)
+        self.ME = ConsistentMassEq(domain, ndof=domain.dim, MP=rho)
+        super()._prepare(domain, self.ME, *args, bcdiagval=bcdiagval, **kwargs)
 
 
 class AssembleScalarMass(AssembleGeneral):
@@ -307,8 +307,8 @@ class AssembleScalarMass(AssembleGeneral):
 
     def _prepare(self, domain: DomainDefinition, *args, MP: float = 1.0, bcdiagval=0.0, **kwargs):
         # Element mass equivalent matrix
-        CE = ConsistentMassEq(domain, ndof=1, MP=MP)
-        super()._prepare(domain, CE, *args, bcdiagval=bcdiagval, **kwargs)
+        self.CE = ConsistentMassEq(domain, ndof=1, MP=MP)
+        super()._prepare(domain, self.CE, *args, bcdiagval=bcdiagval, **kwargs)
 
 
 class AssembleScalarField(AssembleGeneral):

--- a/pymoto/modules/assembly.py
+++ b/pymoto/modules/assembly.py
@@ -230,7 +230,7 @@ def ConsistentMassEq(domain: DomainDefinition, ndof: int, MP: float = 1.0):
     Args:
         domain: The domain the element matrix has to be determined for
         ndof: Amount of dofs per node
-            Mass: ndof = domain.dim
+            Mass, Damping: ndof = domain.dim
             Else: ndof = 1
         MP: Material property to use in the element matrix
             Mass: Density (rho)
@@ -282,9 +282,10 @@ class AssembleMass(AssembleGeneral):
         ME = ConsistentMassEq(domain, ndof=domain.dim, MP=rho)
         super()._prepare(domain, ME, *args, bcdiagval=bcdiagval, **kwargs)
 
+
 class AssembleScalarField(AssembleGeneral):
-    """
-    Scalar field matrix assembly (e.g. Thermal conductivity, Electrical conductivity)
+    r"""
+    Scalar field matrix assembly (e.g. Thermal conductivity, Electric permittivity)
     :math:`\mathbf{Ks} = \sum_e x_e \mathbf{Ks}_e`
 
     Input Signal:
@@ -298,7 +299,7 @@ class AssembleScalarField(AssembleGeneral):
         args (optional): Other arguments are passed to AssembleGeneral
 
     Keyword Args:
-        kt: Material property (e.g. Thermal conductivity, Electrical conductivity)
+        kt: Material property (e.g. Thermal conductivity, Electric permittivity)
         bcdiagval: The value to put on the diagonal in case of boundary conditions (bc)
         kwargs: Other keyword-arguments are passed to AssembleGeneral
     """

--- a/pymoto/modules/assembly.py
+++ b/pymoto/modules/assembly.py
@@ -213,7 +213,7 @@ class AssembleStiffness(AssembleGeneral):
 
         # Numerical integration
         siz = domain.element_size
-        w = np.prod(siz/2)
+        w = np.prod(siz[:domain.dim]/2)
         for n in domain.node_numbering:
             pos = n*(siz/2)/np.sqrt(3)  # Sampling point
             dN_dx = domain.eval_shape_fun_der(pos)
@@ -244,7 +244,9 @@ def ConsistentMassEq(domain: DomainDefinition, ndof: int, MP: float = 1.0):
 
     # Numerical integration
     siz = domain.element_size
-    w = np.prod(siz/2)
+    w = np.prod(siz[:domain.dim]/2)
+    if domain.dim != 3:
+        MP *= np.prod(siz[domain.dim:])
     Nmat = np.zeros((ndof, domain.elemnodes*ndof))
 
     for n in domain.node_numbering:
@@ -336,10 +338,11 @@ class AssembleScalarField(AssembleGeneral):
         kappa = np.identity(domain.dim)*self.kt
         self.SFE = np.zeros((domain.elemnodes, domain.elemnodes))
 
-
         # Numerical Integration
         siz = domain.element_size
-        w = np.prod(siz/2)
+        w = np.prod(siz[:domain.dim]/2)
+        if domain.dim != 3:
+            kappa *= siz[domain.dim:]
 
         for n in domain.node_numbering:
             pos = n*(siz/2)/np.sqrt(3)  # Sampling point

--- a/pymoto/modules/assembly.py
+++ b/pymoto/modules/assembly.py
@@ -283,6 +283,32 @@ class AssembleMass(AssembleGeneral):
         super()._prepare(domain, ME, *args, bcdiagval=bcdiagval, **kwargs)
 
 
+class AssembleScalarMass(AssembleGeneral):
+    r""" Consistent mass equivalent matrix assembly by scaling elements (e.g. Thermal Capacity)
+        :math:`\mathbf{C} = \sum_e x_e \mathbf{C}_e`
+
+        Input Signal:
+            - ``x``: Scaling vector of size ``(Nel)``
+
+        Output Signal:
+            - ``C``: Scalar mass equivalent matrix of size ``(n, n)``
+
+        Args:
+            domain: The domain to assemble for -- this determines the element size and dimensionality
+            *args: Other arguments are passed to AssembleGeneral
+
+        Keyword Args:
+            MP: Material property for element matrix (e.g. Thermal capacity)
+            bcdiagval: The value to put on the diagonal in case of boundary conditions (bc)
+            **kwargs : Other keyword-arguments are passed to AssembleGeneral
+        """
+
+    def _prepare(self, domain: DomainDefinition, *args, MP: float = 1.0, bcdiagval=0.0, **kwargs):
+        # Element mass equivalent matrix
+        CE = ConsistentMassEq(domain, ndof=1, MP=MP)
+        super()._prepare(domain, CE, *args, bcdiagval=bcdiagval, **kwargs)
+
+
 class AssembleScalarField(AssembleGeneral):
     r"""
     Scalar field matrix assembly (e.g. Thermal conductivity, Electric permittivity)

--- a/pymoto/modules/assembly.py
+++ b/pymoto/modules/assembly.py
@@ -279,30 +279,7 @@ class AssembleMass(AssembleGeneral):
 
     def _prepare(self, domain: DomainDefinition, *args, rho: float = 1.0, bcdiagval=0.0, **kwargs):
         # Element mass matrix
-        # 1/36 Mass of one element
-        mel = rho * np.prod(domain.element_size)
-
-        if domain.dim == 2:
-            # Consistent mass matrix
-            ME = mel / 36 * np.array([[4.0, 0.0, 2.0, 0.0, 2.0, 0.0, 1.0, 0.0],
-                                      [0.0, 4.0, 0.0, 2.0, 0.0, 2.0, 0.0, 1.0],
-                                      [2.0, 0.0, 4.0, 0.0, 1.0, 0.0, 2.0, 0.0],
-                                      [0.0, 2.0, 0.0, 4.0, 0.0, 1.0, 0.0, 2.0],
-                                      [2.0, 0.0, 1.0, 0.0, 4.0, 0.0, 2.0, 0.0],
-                                      [0.0, 2.0, 0.0, 1.0, 0.0, 4.0, 0.0, 2.0],
-                                      [1.0, 0.0, 2.0, 0.0, 2.0, 0.0, 4.0, 0.0],
-                                      [0.0, 1.0, 0.0, 2.0, 0.0, 2.0, 0.0, 4.0]])
-        elif domain.dim == 3:
-            ME = np.zeros((domain.elemnodes*domain.dim, domain.elemnodes*domain.dim))
-            weights = np.array([8.0, 4.0, 2.0, 1.0])
-            for n1 in range(domain.elemnodes):
-                for n2 in range(domain.elemnodes):
-                    dist = round(np.sum(abs(np.array(domain.node_numbering[n1]) - np.array(domain.node_numbering[n2])))/2)
-                    ME[n1*domain.dim+np.arange(domain.dim), n2*domain.dim+np.arange(domain.dim)] = weights[dist]
-
-            ME *= mel / 216
-        else:
-            raise RuntimeError("Only for 2D and 3D")
+        ME = ConsistentMassEq(domain, ndof=domain.dim, MP=rho)
         super()._prepare(domain, ME, *args, bcdiagval=bcdiagval, **kwargs)
 
 class AssembleScalarField(AssembleGeneral):

--- a/tests/test_elmatrices.py
+++ b/tests/test_elmatrices.py
@@ -56,6 +56,48 @@ class TestElMats(unittest.TestCase):
 
 
     def TestMassMat3D(self):
+        N = 20
+        Lx, Ly, Lz = 2, 2, 2
+        lx, ly, lz = Lx/N, Ly/N, Lz/N
+        domain = pym.DomainDefinition(N,N,N, unitx = lx, unity = ly, unitz = lz)
+        rho = 1.0
+        mel = rho * np.prod(domain.element_size)
+
+        MEhc = np.zeros((domain.elemnodes * domain.dim, domain.elemnodes * domain.dim))
+        weights = np.array([8.0, 4.0, 2.0, 1.0])
+        for n1 in range(domain.elemnodes):
+            for n2 in range(domain.elemnodes):
+                dist = round(np.sum(abs(np.array(domain.node_numbering[n1]) - np.array(domain.node_numbering[n2]))) / 2)
+                MEhc[n1 * domain.dim + np.arange(domain.dim), n2 * domain.dim + np.arange(domain.dim)] = weights[dist]
+        MEhc *= mel / 216
+
+        ME = pym.ConsistentMassEq(domain, 3, 1.0)
+
+        self.assertEqual(ME, MEhc)
 
 
     def TestConductivityMat3D(self):
+        N = 20
+        Lx, Ly, Lz = 2, 2, 2
+        lx, ly, lz = Lx / N, Ly / N, Lz / N
+        domain = pym.DomainDefinition(N, N, N, unitx=lx, unity=ly, unitz=lz)
+        nodidx_left = domain.get_nodenumber(*np.meshgrid(0, range(domain.nely + 1), range(domain.nelz + 1))).flatten()
+        nodidx_right = domain.get_nodenumber(*np.meshgrid(domain.nelx, range(domain.nely + 1), range(domain.nelz + 1))).flatten()
+
+        kt = 1.0
+
+        s_x = pym.Signal('x', state=np.ones(domain.nel))
+        m_KT = pym.AssembleScalarField(s_x, domain=domain, bc=nodidx_left, kt=kt)
+        s_KT = m_KT.sig_out[0]
+        m_KT.response()
+
+        q = np.zeros(domain.nnodes)
+        Q = 1.0
+        q[nodidx_right] = Q / nodidx_right.size
+
+        # check with simple 1D heat conduction through wall
+        T_chk = Q * Lx / (kt * Ly * Lz)
+        T = np.linalg.solve(s_KT.state.toarray(), q)
+
+        npt.assert_allclose(T[nodidx_right[0]], 0, atol=1e-10)
+        npt.assert_allclose(T[nodidx_right[1]], T_chk, rtol=1e-10)

--- a/tests/test_elmatrices.py
+++ b/tests/test_elmatrices.py
@@ -3,13 +3,15 @@ import numpy as np
 import pymoto as pym
 import numpy.testing as npt
 
+
 class TestElMats(unittest.TestCase):
-    def TestMassMat2D(self):
+    def test_MassMat2D(self):
         N = 20
         Lx, Ly, Lz = 2, 2, 5
         lx, ly, lz = Lx/N, Ly/N, Lz
         domain = pym.DomainDefinition(N,N, unitx = lx, unity = ly, unitz = lz)
         rho = 1.0
+
         mel = rho*np.prod(domain.element_size)
         MEhc = mel / 36 * np.array([[4.0, 0.0, 2.0, 0.0, 2.0, 0.0, 1.0, 0.0],
                                       [0.0, 4.0, 0.0, 2.0, 0.0, 2.0, 0.0, 1.0],
@@ -19,11 +21,14 @@ class TestElMats(unittest.TestCase):
                                       [0.0, 2.0, 0.0, 1.0, 0.0, 4.0, 0.0, 2.0],
                                       [1.0, 0.0, 2.0, 0.0, 2.0, 0.0, 4.0, 0.0],
                                       [0.0, 1.0, 0.0, 2.0, 0.0, 2.0, 0.0, 4.0]])
-        ME = pym.ConsistentMassEq(domain, 2, 1.0)
 
-        self.assertEqual(ME, MEhc)
+        s_x = pym.Signal('x', state=np.ones(domain.nel))
+        m_M = pym.AssembleMass(s_x, domain=domain, rho=rho)
+        ME = m_M.ME
 
-    def TestConductivityMat(self):
+        npt.assert_allclose(ME, MEhc)
+
+    def test_ConductivityMat(self):
         N = 20
         Lx, Ly, Lz = 2, 2, 5
         lx, ly, lz = Lx/N, Ly/N, Lz
@@ -50,12 +55,12 @@ class TestElMats(unittest.TestCase):
         npt.assert_allclose(T[nodidx_right[1]], T_chk, rtol=1e-10)
 
 
-    def TestCapacitanceMat(self):
+    #def test_CapacitanceMat(self):
 
 
 
 
-    def TestMassMat3D(self):
+    def test_MassMat3D(self):
         N = 20
         Lx, Ly, Lz = 2, 2, 2
         lx, ly, lz = Lx/N, Ly/N, Lz/N
@@ -71,12 +76,14 @@ class TestElMats(unittest.TestCase):
                 MEhc[n1 * domain.dim + np.arange(domain.dim), n2 * domain.dim + np.arange(domain.dim)] = weights[dist]
         MEhc *= mel / 216
 
-        ME = pym.ConsistentMassEq(domain, 3, 1.0)
+        s_x = pym.Signal('x', state=np.ones(domain.nel))
+        m_M = pym.AssembleMass(s_x, domain=domain, rho=rho)
+        ME = m_M.ME
 
-        self.assertEqual(ME, MEhc)
+        npt.assert_allclose(ME, MEhc)
 
 
-    def TestConductivityMat3D(self):
+    def test_ConductivityMat3D(self):
         N = 20
         Lx, Ly, Lz = 2, 2, 2
         lx, ly, lz = Lx / N, Ly / N, Lz / N

--- a/tests/test_elmatrices.py
+++ b/tests/test_elmatrices.py
@@ -1,0 +1,38 @@
+import unittest
+import numpy as np
+import pymoto as pym
+
+class TestElMats(unittest.TestCase):
+    def TestMassMat2D(self):
+        N = 20
+        Lx, Ly, Lz = 2, 2, 5
+        lx, ly, lz = Lx/N, Ly/N, Lz
+        domain = pym.DomainDefinition(N,N, unitx = lx, unity = ly, unitz = lz)
+        rho = 1.0
+        mel = rho*np.prod(domain.element_size)
+        MEhc = mel / 36 * np.array([[4.0, 0.0, 2.0, 0.0, 2.0, 0.0, 1.0, 0.0],
+                                      [0.0, 4.0, 0.0, 2.0, 0.0, 2.0, 0.0, 1.0],
+                                      [2.0, 0.0, 4.0, 0.0, 1.0, 0.0, 2.0, 0.0],
+                                      [0.0, 2.0, 0.0, 4.0, 0.0, 1.0, 0.0, 2.0],
+                                      [2.0, 0.0, 1.0, 0.0, 4.0, 0.0, 2.0, 0.0],
+                                      [0.0, 2.0, 0.0, 1.0, 0.0, 4.0, 0.0, 2.0],
+                                      [1.0, 0.0, 2.0, 0.0, 2.0, 0.0, 4.0, 0.0],
+                                      [0.0, 1.0, 0.0, 2.0, 0.0, 2.0, 0.0, 4.0]])
+        ME = pym.ConsistentMassEq(domain, 2, 1.0)
+
+        self.assertEqual(ME, MEhc)
+
+    def TestConductivityMat(self):
+
+
+
+
+    def TestCapacitanceMat(self):
+
+
+
+
+    def TestMassMat3D(self):
+
+
+    def TestConductivityMat3D(self):

--- a/tests/test_elmatrices.py
+++ b/tests/test_elmatrices.py
@@ -9,18 +9,19 @@ class TestElMats(unittest.TestCase):
         N = 1
         Lx, Ly, Lz = 2, 3, 4
         lx, ly, lz = Lx/N, Ly/N, Lz
-        domain = pym.DomainDefinition(N,N, unitx = lx, unity = ly, unitz = lz)
+        domain = pym.DomainDefinition(N, N, unitx=lx, unity=ly, unitz=lz)
         rho = 1.0
 
+        # Hard coded mass element matrix, taken from Cook (eq 11.3-6)
         mel = rho*np.prod(domain.element_size)
         MEhc = mel / 36 * np.array([[4.0, 0.0, 2.0, 0.0, 2.0, 0.0, 1.0, 0.0],
-                                      [0.0, 4.0, 0.0, 2.0, 0.0, 2.0, 0.0, 1.0],
-                                      [2.0, 0.0, 4.0, 0.0, 1.0, 0.0, 2.0, 0.0],
-                                      [0.0, 2.0, 0.0, 4.0, 0.0, 1.0, 0.0, 2.0],
-                                      [2.0, 0.0, 1.0, 0.0, 4.0, 0.0, 2.0, 0.0],
-                                      [0.0, 2.0, 0.0, 1.0, 0.0, 4.0, 0.0, 2.0],
-                                      [1.0, 0.0, 2.0, 0.0, 2.0, 0.0, 4.0, 0.0],
-                                      [0.0, 1.0, 0.0, 2.0, 0.0, 2.0, 0.0, 4.0]])
+                                    [0.0, 4.0, 0.0, 2.0, 0.0, 2.0, 0.0, 1.0],
+                                    [2.0, 0.0, 4.0, 0.0, 1.0, 0.0, 2.0, 0.0],
+                                    [0.0, 2.0, 0.0, 4.0, 0.0, 1.0, 0.0, 2.0],
+                                    [2.0, 0.0, 1.0, 0.0, 4.0, 0.0, 2.0, 0.0],
+                                    [0.0, 2.0, 0.0, 1.0, 0.0, 4.0, 0.0, 2.0],
+                                    [1.0, 0.0, 2.0, 0.0, 2.0, 0.0, 4.0, 0.0],
+                                    [0.0, 1.0, 0.0, 2.0, 0.0, 2.0, 0.0, 4.0]])
 
         s_x = pym.Signal('x', state=np.ones(domain.nel))
         m_M = pym.AssembleMass(s_x, domain=domain, rho=rho)
@@ -32,10 +33,9 @@ class TestElMats(unittest.TestCase):
         N = 1
         Lx, Ly, Lz = 2, 3, 4
         lx, ly, lz = Lx/N, Ly/N, Lz
-        domain = pym.DomainDefinition(N,N, unitx = lx, unity = ly, unitz = lz)
+        domain = pym.DomainDefinition(N, N, unitx=lx, unity=ly, unitz=lz)
         nodidx_left = domain.get_nodenumber(0, np.arange(domain.nely + 1))
         nodidx_right = domain.get_nodenumber(domain.nelx, np.arange(domain.nely + 1))
-
         kt = 1.0
 
         s_x = pym.Signal('x', state=np.ones(domain.nel))
@@ -47,13 +47,13 @@ class TestElMats(unittest.TestCase):
         Q = 1.0
         q[nodidx_right] = Q / nodidx_right.size
 
-        # check with simple 1D heat conduction through wall
+        # check with simple 1D heat conduction through wall Q = -k (dT/dx)
         T_chk = Q*Lx/(kt*Ly*Lz)
         T = np.linalg.solve(s_KT.state.toarray(), q)
 
+        # Check if left boundary has T=0 and right boundary has T=T_chk
         npt.assert_allclose(T[nodidx_left], 0, atol=1e-10)
         npt.assert_allclose(T[nodidx_right], T_chk, rtol=1e-10)
-
 
     def test_CapacitanceMat(self):
         N = 1
@@ -63,6 +63,7 @@ class TestElMats(unittest.TestCase):
         rho = 1.0
         cp = 1.0
 
+        # Hard coded thermal capacity matrix, taken from Cook eq 12.2-4, where it is a 1 dof version of mass element
         cel = cp*rho*np.prod(domain.element_size)
         CEhc = cel / 36 * np.array([[4.0, 2.0, 2.0, 1.0],
                                     [2.0, 4.0, 1.0, 2.0],
@@ -83,6 +84,7 @@ class TestElMats(unittest.TestCase):
         rho = 1.0
         mel = rho * np.prod(domain.element_size)
 
+        # Hard coded mass element matrix
         MEhc = np.zeros((domain.elemnodes * domain.dim, domain.elemnodes * domain.dim))
         weights = np.array([8.0, 4.0, 2.0, 1.0])
         for n1 in range(domain.elemnodes):
@@ -97,7 +99,6 @@ class TestElMats(unittest.TestCase):
 
         npt.assert_allclose(ME, MEhc)
 
-
     def test_ConductivityMat3D(self):
         N = 1
         Lx, Ly, Lz = 2, 3, 4
@@ -105,7 +106,6 @@ class TestElMats(unittest.TestCase):
         domain = pym.DomainDefinition(N, N, N, unitx=lx, unity=ly, unitz=lz)
         nodidx_left = domain.get_nodenumber(*np.meshgrid(0, range(domain.nely + 1), range(domain.nelz + 1))).flatten()
         nodidx_right = domain.get_nodenumber(*np.meshgrid(domain.nelx, range(domain.nely + 1), range(domain.nelz + 1))).flatten()
-
         kt = 1.0
 
         s_x = pym.Signal('x', state=np.ones(domain.nel))
@@ -121,5 +121,6 @@ class TestElMats(unittest.TestCase):
         T_chk = Q * Lx / (kt * Ly * Lz)
         T = np.linalg.solve(s_KT.state.toarray(), q)
 
+        # Check if left boundary has T=0 and right boundary has T=T_chk
         npt.assert_allclose(T[nodidx_left], 0, atol=1e-10)
         npt.assert_allclose(T[nodidx_right], T_chk, rtol=1e-10)

--- a/tests/test_elmatrices.py
+++ b/tests/test_elmatrices.py
@@ -6,8 +6,8 @@ import numpy.testing as npt
 
 class TestElMats(unittest.TestCase):
     def test_MassMat2D(self):
-        N = 20
-        Lx, Ly, Lz = 2, 2, 5
+        N = 1
+        Lx, Ly, Lz = 2, 3, 4
         lx, ly, lz = Lx/N, Ly/N, Lz
         domain = pym.DomainDefinition(N,N, unitx = lx, unity = ly, unitz = lz)
         rho = 1.0
@@ -30,7 +30,7 @@ class TestElMats(unittest.TestCase):
 
     def test_ConductivityMat(self):
         N = 1
-        Lx, Ly, Lz = 2, 2, 5
+        Lx, Ly, Lz = 2, 3, 4
         lx, ly, lz = Lx/N, Ly/N, Lz
         domain = pym.DomainDefinition(N,N, unitx = lx, unity = ly, unitz = lz)
         nodidx_left = domain.get_nodenumber(0, np.arange(domain.nely + 1))
@@ -61,10 +61,10 @@ class TestElMats(unittest.TestCase):
 
 
     def test_MassMat3D(self):
-        N = 20
-        Lx, Ly, Lz = 2, 2, 2
+        N = 1
+        Lx, Ly, Lz = 2, 3, 4
         lx, ly, lz = Lx/N, Ly/N, Lz/N
-        domain = pym.DomainDefinition(N,N,N, unitx = lx, unity = ly, unitz = lz)
+        domain = pym.DomainDefinition(N, N, N, unitx=lx, unity=ly, unitz=lz)
         rho = 1.0
         mel = rho * np.prod(domain.element_size)
 
@@ -85,7 +85,7 @@ class TestElMats(unittest.TestCase):
 
     def test_ConductivityMat3D(self):
         N = 1
-        Lx, Ly, Lz = 2, 2, 2
+        Lx, Ly, Lz = 2, 3, 4
         lx, ly, lz = Lx / N, Ly / N, Lz / N
         domain = pym.DomainDefinition(N, N, N, unitx=lx, unity=ly, unitz=lz)
         nodidx_left = domain.get_nodenumber(*np.meshgrid(0, range(domain.nely + 1), range(domain.nelz + 1))).flatten()

--- a/tests/test_elmatrices.py
+++ b/tests/test_elmatrices.py
@@ -29,7 +29,7 @@ class TestElMats(unittest.TestCase):
         npt.assert_allclose(ME, MEhc)
 
     def test_ConductivityMat(self):
-        N = 20
+        N = 1
         Lx, Ly, Lz = 2, 2, 5
         lx, ly, lz = Lx/N, Ly/N, Lz
         domain = pym.DomainDefinition(N,N, unitx = lx, unity = ly, unitz = lz)
@@ -51,8 +51,8 @@ class TestElMats(unittest.TestCase):
         T_chk = Q*Lx/(kt*Ly*Lz)
         T = np.linalg.solve(s_KT.state.toarray(), q)
 
-        npt.assert_allclose(T[nodidx_right[0]], 0, atol=1e-10)
-        npt.assert_allclose(T[nodidx_right[1]], T_chk, rtol=1e-10)
+        npt.assert_allclose(T[nodidx_left], 0, atol=1e-10)
+        npt.assert_allclose(T[nodidx_right], T_chk, rtol=1e-10)
 
 
     #def test_CapacitanceMat(self):
@@ -84,7 +84,7 @@ class TestElMats(unittest.TestCase):
 
 
     def test_ConductivityMat3D(self):
-        N = 20
+        N = 1
         Lx, Ly, Lz = 2, 2, 2
         lx, ly, lz = Lx / N, Ly / N, Lz / N
         domain = pym.DomainDefinition(N, N, N, unitx=lx, unity=ly, unitz=lz)
@@ -106,5 +106,5 @@ class TestElMats(unittest.TestCase):
         T_chk = Q * Lx / (kt * Ly * Lz)
         T = np.linalg.solve(s_KT.state.toarray(), q)
 
-        npt.assert_allclose(T[nodidx_right[0]], 0, atol=1e-10)
-        npt.assert_allclose(T[nodidx_right[1]], T_chk, rtol=1e-10)
+        npt.assert_allclose(T[nodidx_left], 0, atol=1e-10)
+        npt.assert_allclose(T[nodidx_right], T_chk, rtol=1e-10)

--- a/tests/test_elmatrices.py
+++ b/tests/test_elmatrices.py
@@ -55,10 +55,25 @@ class TestElMats(unittest.TestCase):
         npt.assert_allclose(T[nodidx_right], T_chk, rtol=1e-10)
 
 
-    #def test_CapacitanceMat(self):
+    def test_CapacitanceMat(self):
+        N = 1
+        Lx, Ly, Lz = 2, 3, 4
+        lx, ly, lz = Lx/N, Ly/N, Lz
+        domain = pym.DomainDefinition(N, N, unitx=lx, unity=ly, unitz=lz)
+        rho = 1.0
+        cp = 1.0
 
+        cel = cp*rho*np.prod(domain.element_size)
+        CEhc = cel / 36 * np.array([[4.0, 2.0, 2.0, 1.0],
+                                    [2.0, 4.0, 1.0, 2.0],
+                                    [2.0, 1.0, 4.0, 2.0],
+                                    [1.0, 2.0, 2.0, 4.0]])
 
+        s_x = pym.Signal('x', state=np.ones(domain.nel))
+        m_C = pym.AssembleScalarMass(s_x, domain=domain, MP=rho*cp)
+        CE = m_C.CE
 
+        npt.assert_allclose(CE, CEhc)
 
     def test_MassMat3D(self):
         N = 1

--- a/tests/test_elmatrices.py
+++ b/tests/test_elmatrices.py
@@ -1,6 +1,7 @@
 import unittest
 import numpy as np
 import pymoto as pym
+import numpy.testing as npt
 
 class TestElMats(unittest.TestCase):
     def TestMassMat2D(self):
@@ -23,8 +24,30 @@ class TestElMats(unittest.TestCase):
         self.assertEqual(ME, MEhc)
 
     def TestConductivityMat(self):
+        N = 20
+        Lx, Ly, Lz = 2, 2, 5
+        lx, ly, lz = Lx/N, Ly/N, Lz
+        domain = pym.DomainDefinition(N,N, unitx = lx, unity = ly, unitz = lz)
+        nodidx_left = domain.get_nodenumber(0, np.arange(domain.nely + 1))
+        nodidx_right = domain.get_nodenumber(domain.nelx, np.arange(domain.nely + 1))
 
+        kt = 1.0
 
+        s_x = pym.Signal('x', state=np.ones(domain.nel))
+        m_KT = pym.AssembleScalarField(s_x, domain=domain, bc=nodidx_left, kt = kt)
+        s_KT = m_KT.sig_out[0]
+        m_KT.response()
+
+        q = np.zeros(domain.nnodes)
+        Q = 1.0
+        q[nodidx_right] = Q / nodidx_right.size
+
+        # check with simple 1D heat conduction through wall
+        T_chk = Q*Lx/(kt*Ly*Lz)
+        T = np.linalg.solve(s_KT.state.toarray(), q)
+
+        npt.assert_allclose(T[nodidx_right[0]], 0, atol=1e-10)
+        npt.assert_allclose(T[nodidx_right[1]], T_chk, rtol=1e-10)
 
 
     def TestCapacitanceMat(self):


### PR DESCRIPTION
Added matrix assemblies for scalar fields, scalar mass and mass
- Changed AssembleMass so that it uses shape functions rather than a hard coded element matrix.
- Added AssembleScalarField and AssembleScalarMass, to determine matrices for thermal problems, for example.
- Implemented tests for new Assemble modules