### PR TITLE
Convolution filter

### DIFF
--- a/pymoto/modules/filter.py
+++ b/pymoto/modules/filter.py
@@ -6,7 +6,7 @@ from scipy.signal import convolve, correlate
 
 
 class FilterConv(Module):
-    def _prepare(self, domain: DomainDefinition, radius: float = None, relative_units: bool = True, weights: np.ndarray = None, mode: str = 'reflect', origin: np.ndarray = None, cval: float = 0.0):
+    def _prepare(self, domain: DomainDefinition, radius: float = None, relative_units: bool = True, weights: np.ndarray = None):
         self.domain = domain
         if (weights is None and radius is None) or (weights is not None and radius is not None):
             raise ValueError("Only one of arguments 'filter_radius' or 'weights' must be provided.")
@@ -18,9 +18,6 @@ class FilterConv(Module):
                 assert self.weights.shape[i]%2==1, "Size of weights must be uneven"
         elif radius is not None:
             self.set_filter_radius(radius, relative_units)
-        self.mode = mode
-        self.origin = origin if origin is not None else np.array([0, 0, 0])
-        self.cval = cval
 
         # Process padding
         # TODO Other options than reflect: wrap, constant, extend, ... and choose at which faces/edges/corners

--- a/tests/test_filter.py
+++ b/tests/test_filter.py
@@ -1,0 +1,112 @@
+import unittest
+import numpy as np
+import pymoto as pym
+import numpy.testing as npt
+import matplotlib.pyplot as plt
+import time
+
+
+def fd_testfn(x0, dx, df_an, df_fd, rtol=1e-5, atol=1e-5):
+    npt.assert_allclose(df_an, df_fd, rtol=rtol, atol=atol)
+
+
+class TestConvolutionFilter(unittest.TestCase):
+    def test_2D_dot(self):
+        np.random.seed(0)
+        domain = pym.DomainDefinition(10, 12)
+
+        ix, iy = 5, 6
+
+        x = np.zeros(domain.nel)
+        x[domain.get_elemnumber(ix, iy)] = 1.0
+        sx = pym.Signal('x', state=x)
+
+        m = pym.FilterConv(sx, domain=domain, radius=2, relative_units=True)
+        m.response()
+
+        y = m.sig_out[0].state
+        w = m.weights
+
+        npt.assert_allclose(y[domain.get_elemnumber(ix, iy)], w[1,1,0])
+        npt.assert_allclose(y[domain.get_elemnumber(ix+1, iy)], w[2,1,0])
+        npt.assert_allclose(y[domain.get_elemnumber(ix, iy+1)], w[1,2,0])
+        npt.assert_allclose(y[domain.get_elemnumber(ix-1, iy)], w[0,1,0])
+        npt.assert_allclose(y[domain.get_elemnumber(ix, iy-1)], w[1,0,0])
+        npt.assert_allclose(y[domain.get_elemnumber(ix+1, iy+1)], w[2, 2, 0])
+        npt.assert_allclose(y[domain.get_elemnumber(ix-1, iy+1)], w[0, 2, 0])
+        npt.assert_allclose(y[domain.get_elemnumber(ix-1, iy-1)], w[0, 0, 0])
+        npt.assert_allclose(y[domain.get_elemnumber(ix+1, iy-1)], w[2, 0, 0])
+
+    def test_2D_symmetric(self):
+        np.random.seed(0)
+        domain = pym.DomainDefinition(10, 12, unitx=0.5, unity=1.0)
+
+        sx = pym.Signal('x', state=np.random.rand(domain.nel))
+
+        m = pym.FilterConv(sx, domain=domain, radius=5.3, relative_units=False)
+
+        pym.finite_difference(m, test_fn=fd_testfn)
+
+    def test_2D_asymmetric(self):
+        np.random.seed(0)
+        domain = pym.DomainDefinition(10, 21)
+
+        x = np.random.rand(domain.nel)
+
+        sx = pym.Signal('x', state=x)
+        nx, ny = 3, 1
+        weights = 1+np.arange(nx*ny).reshape((nx, ny, 1))
+        m = pym.FilterConv(sx, domain=domain, weights=weights, mode='reflect')
+
+        pym.finite_difference(m, test_fn=fd_testfn)
+
+    def test_3D_dot(self):
+        np.random.seed(0)
+        domain = pym.DomainDefinition(10, 11, 12)
+
+        ix, iy, iz = 5, 6, 7
+
+        x = np.zeros(domain.nel)
+        x[domain.get_elemnumber(ix, iy, iz)] = 1.0
+        sx = pym.Signal('x', state=x)
+
+        m = pym.FilterConv(sx, domain=domain, radius=2, relative_units=True)
+        m.response()
+
+        y = m.sig_out[0].state
+        w = m.weights
+
+        for i in range(3):
+            for j in range(3):
+                for k in range(3):
+                    npt.assert_allclose(y[domain.get_elemnumber(ix-1+i, iy-1+j, iz-1+k)], w[i,j,k])
+
+    def test_3D_symmetric(self):
+        np.random.seed(0)
+        domain = pym.DomainDefinition(10, 12, 13, unitx=0.5, unity=1.0, unitz=1.2)
+
+        sx = pym.Signal('x', state=np.random.rand(domain.nel))
+
+        m = pym.FilterConv(sx, domain=domain, radius=5.3, relative_units=False)
+
+        pym.finite_difference(m, test_fn=fd_testfn)
+
+    def test_3D_symmetric1(self):
+        np.random.seed(0)
+        domain = pym.DomainDefinition(100, 120, 13, unitx=0.5, unity=1.0, unitz=1.2)
+
+        sx = pym.Signal('x', state=np.random.rand(domain.nel))
+        start = time.time()
+        m1 = pym.FilterConv(sx, domain=domain, radius=5.3, relative_units=True)
+        print(f"Convolution setup = {time.time() - start} s")
+        start = time.time()
+        m1.response()
+        print(f"Convolution elapsed = {time.time() - start} s")
+
+        start = time.time()
+        m2 = pym.DensityFilter(sx, domain=domain, radius=5.3)
+        print(f"H-matrix setup = {time.time() - start} s")
+        start = time.time()
+        m2.response()
+        print(f"H-matrix elapsed = {time.time() - start} s")
+


### PR DESCRIPTION
I've added a convolution filter that is much faster than the regular matrix-based density filter.
Reasons to add:
- Setup cost is next to none (for H-matrix it can go up to seconds-minutes with a large filter radius and large domain). For a 3D domain of 60^3 with filter radius 5 elements, setup of H-matrix is 12 seconds, while for convolution it is 0.0059.
- Execution cost is low, since convolution makes use of efficient FFT algorithms. For the 3D domain aforementioned, running convolution costs only 0.023s, while H-matrix is almost 10x slower at 0.16s.
- Flexible boundary conditions: padding is required to extend the domain for the convolution to work. This allows different regions to have different behavior (e.g. reflection, constant value, wrap around, ...).