### PR TITLE
ScalarToFile to output scalar values to txt or csv files

### DIFF
--- a/examples/topology_optimization/ex_eigenfrequency.py
+++ b/examples/topology_optimization/ex_eigenfrequency.py
@@ -1,6 +1,6 @@
 """ Minimal example for an eigenfrequency topology optimization """
 import numpy as np
-
+import csv
 import pymoto as pym
 
 nx, ny, nz = 50, 30, 0  # Set nz to zero for the 2D problem
@@ -113,12 +113,14 @@ if __name__ == "__main__":
 
     # Linear system solver. The linear solver can be chosen by uncommenting any of the following lines.
     slams, seigvec = func.append(pym.EigenSolve([sK, sM], hermitian=True, nmodes=3))
+    slams.tag = "eigenfrequency"
 
     # Output the design, deformation, and force field to a Paraview file
     func.append(pym.WriteToVTI([sx_analysis], domain=domain, saveto='out/dat.vti'))
 
     # Get harmonic mean of three lowest eigenvalues
     sharm = func.append(pym.MathGeneral([slams[0], slams[1], slams[2]], expression='1/inp0 + 1/inp1 + 1/inp2'))
+    sharm.tag = "harmonic mean"
 
     # MMA needs correct scaling of the objective
     sg0 = func.append(pym.Scaling(sharm, scaling=100.0))
@@ -139,6 +141,7 @@ if __name__ == "__main__":
         exit()
 
     func.append(pym.PlotIter([sg0, sg1]))  # Plot iteration history
+    func.append(pym.ScalarToFile([sharm, slams, svol]))
 
     # Do the optimization with MMA
     pym.minimize_mma(func, [sx], [sg0, sg1], verbosity=2)

--- a/pymoto/__init__.py
+++ b/pymoto/__init__.py
@@ -19,7 +19,7 @@ from .modules.autodiff import AutoMod
 from .modules.complex import MakeComplex, RealPart, ImagPart, ComplexNorm
 from .modules.filter import FilterConv, Filter, DensityFilter, OverhangFilter
 from .modules.generic import MathGeneral, EinSum, ConcatSignal
-from .modules.io import FigModule, PlotDomain, PlotGraph, PlotIter, WriteToVTI
+from .modules.io import FigModule, PlotDomain, PlotGraph, PlotIter, WriteToVTI, ScalarToFile
 from .modules.linalg import Inverse, LinSolve, EigenSolve, SystemOfEquations, StaticCondensation
 from .modules.aggregation import AggScaling, AggActiveSet, Aggregation, PNorm, SoftMinMax, KSFunction
 from .modules.scaling import Scaling
@@ -46,7 +46,7 @@ __all__ = [
     "AssembleGeneral", "AssembleStiffness", "AssembleMass", "AssemblePoisson",
     "ElementOperation", "Strain", "Stress",
     "FilterConv", "Filter", "DensityFilter", "OverhangFilter",
-    "FigModule", "PlotDomain", "PlotGraph", "PlotIter", "WriteToVTI",
+    "FigModule", "PlotDomain", "PlotGraph", "PlotIter", "WriteToVTI", "ScalarToFile",
     "MakeComplex", "RealPart", "ImagPart", "ComplexNorm",
     "AutoMod",
     "Aggregation", "PNorm", "SoftMinMax", "KSFunction",

--- a/pymoto/modules/io.py
+++ b/pymoto/modules/io.py
@@ -285,15 +285,13 @@ class WriteToVTI(Module):
 
 
 class ScalarToFile(Module):
-    def _prepare(self, path=".", filename="log.txt"):
-        self.path = path
-        self.filename = filename
-        self.file = os.path.join(self.path, self.filename)
+    def _prepare(self, saveto="log.txt"):
+        self.file = saveto
 
-        if self.filename.find(".csv") > 0:
+        if self.file.find(".csv") > 0:
             self.separator = ", "
         else:
-            self.separator = "\t\t"
+            self.separator = "\t"
 
         newline = ["#iter",] + [s.tag for s in self.sig_in]
         with open(self.file, "w+") as f:
@@ -308,7 +306,7 @@ class ScalarToFile(Module):
             data.append(s.state)
         with open(self.file, "a+") as f:
             f.write("{:04d}".format(self.iter) + self.separator)
-            f.write(self.separator.join(['%.5f' % d for d in data]))
+            f.write(self.separator.join(['%.4E' % d for d in data]))
             f.write("\n")
 
         self.iter += 1

--- a/pymoto/modules/io.py
+++ b/pymoto/modules/io.py
@@ -282,3 +282,33 @@ class WriteToVTI(Module):
             filen = pth[0] + '.{0:04d}'.format(self.iter) + pth[1]
         self.domain.write_to_vti(data, filename=filen, scale=self.scale)
         self.iter += 1
+
+
+class ScalarToFile(Module):
+    def _prepare(self, path=".", filename="log.txt"):
+        self.path = path
+        self.filename = filename
+        self.file = os.path.join(self.path, self.filename)
+
+        if self.filename.find(".csv") > 0:
+            self.separator = ", "
+        else:
+            self.separator = "\t\t"
+
+        newline = ["#iter",] + [s.tag for s in self.sig_in]
+        with open(self.file, "w+") as f:
+            f.write(self.separator.join(newline))
+            f.write("\n")
+
+        self.iter = 0
+
+    def _response(self, *args):
+        data = []
+        for s in self.sig_in:
+            data.append(s.state)
+        with open(self.file, "a+") as f:
+            f.write("{:04d}".format(self.iter) + self.separator)
+            f.write(self.separator.join(['%.5f' % d for d in data]))
+            f.write("\n")
+
+        self.iter += 1

--- a/pymoto/modules/io.py
+++ b/pymoto/modules/io.py
@@ -318,7 +318,7 @@ class ScalarToFile(Module):
             for i in range(scal.size):
                 scalname = key
                 if scal.size > 1:
-                    names_to_write.append(scalname + f"({i})")
+                    names_to_write.append(scalname + f"_{i}")
                     data_to_write.append(scal[i])
                 else:
                     names_to_write.append(scalname)

--- a/pymoto/modules/io.py
+++ b/pymoto/modules/io.py
@@ -255,7 +255,7 @@ class WriteToVTI(Module):
     accepted, which get the suffixed as ``_00``.
 
     Input Signals:
-      - ``*args`` (`numpy.ndarary`): Vectors to write to VTI. The signal tags are used as name.
+      - ``*args`` (`numpy.ndarray`): Vectors to write to VTI. The signal tags are used as name.
 
     Args:
         domain: The domain layout
@@ -285,8 +285,20 @@ class WriteToVTI(Module):
 
 
 class ScalarToFile(Module):
+    """ Writes scalars to a log file
+
+    This function can also handle small vectors of scalars, i.e. eigenfrequencies or multiple constraints. Scalars are
+    saved in scientific notation with 4 significant digits.
+
+    Input Signals:
+      - ``*args`` (`Numeric or List`): Scalars to write to file. The signal tags are used as name.
+
+    Args:
+        saveto (str): Location to save the log file, supports .txt or .csv
+    """
     def _prepare(self, saveto="log.txt"):
         self.file = saveto
+        Path(saveto).parent.mkdir(parents=True, exist_ok=True)
         self.iter = 0
 
         if self.file.find(".csv") > 0:


### PR DESCRIPTION
Added module to output scalar values to txt or csv files. 
Also supports signals containing multiple scalars (i.e. multiple eigenfrequencies). Removing this support would make `_response()` a lot cleaner if that's something to consider.